### PR TITLE
[feat] 사용자 프롬프트 리라이팅 구현(DeepSeek 사용)

### DIFF
--- a/src/main/java/hello/backend/ai/deepseek/service/DeepSeekService.java
+++ b/src/main/java/hello/backend/ai/deepseek/service/DeepSeekService.java
@@ -1,0 +1,92 @@
+package hello.backend.ai.deepseek.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class DeepSeekService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${deepseek.api.url}")
+    private String apiUrl;
+
+    @Value("${deepseek.api.model}")
+    private String model;
+
+    // text prompt
+    public String textTransFormScript(String userScript) {
+        String prompt = """
+            Convert the following sentence into a short, natural scenario suitable for an advertising video scene.
+                - The main theme is "<Insert your main keyword here>".
+                - The product must remain stationary and must not move.
+                - The product must always remain sharply in focus, clearly visible, and be the primary visual element of the scene.
+                - Natural elements should remain complementary and subtle, enhancing but never distracting from the clearly-focused product.
+                - Keep it concise and poetic, within approximately 3 sentences, and realistic enough to film directly.
+                - Provide your response entirely in English.
+            The sentence I want you to convert is:
+            """ + userScript;
+
+        Map<String, Object> requestBody = Map.of(
+                "model", model,
+                "messages", List.of(Map.of(
+                        "role", "user",
+                        "content", prompt
+                ))
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(apiUrl, HttpMethod.POST, entity, Map.class);
+
+        List<Map<String, Object>> choices = (List<Map<String, Object>>) response.getBody().get("choices");
+        Map<String, Object> firstChoice = choices.get(0);
+        Map<String, String> message = (Map<String, String>) firstChoice.get("message");
+        return message.get("content");
+    }
+
+    // image prompt
+    public String imageTransFormScript(String userScript) {
+        String prompt = """
+            Convert the following sentence into a short, natural scenario suitable for an advertising video scene.
+                - The main theme is "<Insert your main keyword here>".
+                - The product must remain stationary and must not move.
+                - The product must always remain sharply in focus, clearly visible, and be the primary visual element of the scene. Never blur, obscure, or overshadow the product with any natural elements, transitions, or camera effects.
+                - Natural elements should remain complementary and subtle, enhancing but never distracting from the clearly-focused product.
+                - Keep it concise and poetic, within approximately 3 sentences, and realistic enough to film directly.
+                - Provide your response entirely in English.
+            The sentence I want you to convert is:
+            """ + userScript;
+
+        Map<String, Object> requestBody = Map.of(
+                "model", model,
+                "messages", List.of(Map.of(
+                        "role", "user",
+                        "content", prompt
+                ))
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(apiUrl, HttpMethod.POST, entity, Map.class);
+
+        List<Map<String, Object>> choices = (List<Map<String, Object>>) response.getBody().get("choices");
+        Map<String, Object> firstChoice = choices.get(0);
+        Map<String, String> message = (Map<String, String>) firstChoice.get("message");
+        return message.get("content");
+    }
+}

--- a/src/main/java/hello/backend/config/DeepSeekConfig.java
+++ b/src/main/java/hello/backend/config/DeepSeekConfig.java
@@ -1,0 +1,24 @@
+package hello.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class DeepSeekConfig {
+
+    @Value("${deepseek.api.key}")
+    private String apiKey;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        RestTemplate template = new RestTemplate();
+        template.getInterceptors().add((request, body, execution) -> {
+            request.getHeaders().add("Authorization", "Bearer " + apiKey);
+            return execution.execute(request, body);
+        });
+
+        return template;
+    }
+}

--- a/src/main/java/hello/backend/config/FalConfig.java
+++ b/src/main/java/hello/backend/config/FalConfig.java
@@ -1,4 +1,4 @@
-package hello.backend.video.domain;
+package hello.backend.config;
 
 import ai.fal.client.FalClient;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/hello/backend/video/contoller/VideoController.java
+++ b/src/main/java/hello/backend/video/contoller/VideoController.java
@@ -1,6 +1,7 @@
 package hello.backend.video.contoller;
 
 import com.google.gson.JsonObject;
+import hello.backend.ai.deepseek.service.DeepSeekService;
 import hello.backend.video.dto.*;
 import hello.backend.video.service.VideoService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class VideoController {
     private final VideoService videoService;
+    private final DeepSeekService deepSeekService;
 
     @Operation(summary = "text to video 생성", description = "텍스트를 기반으로 영상을 생성합니다.")
     @ApiResponses(value = {
@@ -24,7 +26,9 @@ public class VideoController {
     })
     @PostMapping("/text")
     public ResponseEntity<TextToVideoResponse> createTextToVideo(@RequestBody TextToVideoRequest request) {
-        JsonObject createTextToVideo = videoService.createTextToVideo(request);
+        String finalprompt = deepSeekService.textTransFormScript(request.getPrompt());
+        JsonObject createTextToVideo = videoService.createTextToVideo(request, finalprompt);
+
         TextToVideoResponse response = TextToVideoResponse.from(createTextToVideo,
                 request.getAspect_ratio(),
                 request.getDuration());
@@ -38,7 +42,9 @@ public class VideoController {
     })
     @PostMapping("/image")
     public ResponseEntity<ImageToVideoResponse> createImageToVideo(@RequestBody ImageToVideoRequest request) {
-        JsonObject createImageToVideo = videoService.createImageToVideo(request);
+        String finalprompt = deepSeekService.imageTransFormScript(request.getPrompt());
+        JsonObject createImageToVideo = videoService.createImageToVideo(request, finalprompt);
+
         ImageToVideoResponse response = ImageToVideoResponse.from(createImageToVideo,
                 request.getDuration()
         , request.getAspect_ratio());
@@ -60,5 +66,15 @@ public class VideoController {
         SaveResponse response = videoService.saveVideo(userId, request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "DeepSeek prompt 테스트", description = "prompt를 DeepSeek에 보내 변환된 결과를 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "변환 성공")
+    })
+    @PostMapping("/transform")
+    public ResponseEntity<String> transformPrompt(@RequestBody String prompt) {
+        String result = deepSeekService.textTransFormScript(prompt);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/hello/backend/video/service/VideoService.java
+++ b/src/main/java/hello/backend/video/service/VideoService.java
@@ -29,10 +29,10 @@ public class VideoService {
 
     //text-to-video 생성
     @Transactional
-    public JsonObject createTextToVideo(TextToVideoRequest request) {
+    public JsonObject createTextToVideo(TextToVideoRequest request, String finalprompt) {
 
         Map<String, Object> input = Map.of(
-                "prompt", request.getPrompt(),
+                "prompt", finalprompt,
                 "aspect_ratio", request.getAspect_ratio(),
                 "duration", request.getDuration()
         );
@@ -57,11 +57,11 @@ public class VideoService {
 
     //image-to-video 생성
     @Transactional
-    public JsonObject createImageToVideo(ImageToVideoRequest request) {
+    public JsonObject createImageToVideo(ImageToVideoRequest request, String finalprompt) {
 
         Map<String, Object> input = Map.of(
                 "image_url", request.getImageUrl(),
-                "prompt", request.getPrompt(),
+                "prompt", finalprompt,
                 "resolution", "1080p",
                 "aspect_ratio", request.getAspect_ratio(),
                 "duration", request.getDuration()


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

사용자 프롬프트 리라이팅 구현

---

### ✨ Description

<!-- write down the work details and show the execution results. -->

사용자 프롬프트 리라이팅 구현 완료했습니다.
![image](https://github.com/user-attachments/assets/d211431f-af77-42af-ab65-e92a387c90ae)
- 위 사진처럼 사용자 프롬프트를 받으면, LLM 모델을 통해 최적의 영상 프롬프트로 리라이팅 해줍니다.

https://v3.fal.media/files/zebra/U-4KlXyFqzejIR4XdU7DL_output.mp4
- 위 리라이팅을 적용시킨 영상입니다. 전 pr 영상보다 프롬프트를 더욱 잘 반영하게 영상이 생성되었습니다.

https://v3.fal.media/files/rabbit/RUFA92AD4wHh8-RB5XIOV_output.mp4
- 위 리라이팅을 적용시킨 영상입니다. image-to-video 기반 프롬프트를 변형 시켰지만, 생각보다 원하는 느낌의 영상이 나오지 않았습니다.
 이는, 추후 리팩토링을 통해 프롬프트를 강화시킬 계획입니다.

또한, env파일 수정 완료했습니다.
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{35}
