### PR TITLE
[refactor] Video 비동기 큐 적용 리팩토링 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     //fal.ai 설정
     implementation 'ai.fal.client:fal-client:0.7.1'
+    //caffeine 설정(임시 캐시)
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       - DRAPH_ART_TOKEN=${DRAPH_ART_TOKEN}
       - DRAPH_ART_USERNAME=${DRAPH_ART_USERNAME}
       - FILE_FINAL_DIR=${FILE_FINAL_DIR}
-      - SPRING_WEBCLIENT_TIMEOUT=60000
     depends_on:
       db:
         condition: service_healthy

--- a/src/main/java/hello/backend/config/CaffeineConfig.java
+++ b/src/main/java/hello/backend/config/CaffeineConfig.java
@@ -1,0 +1,4 @@
+package hello.backend.config;
+
+public class CaffeineConfig {
+}

--- a/src/main/java/hello/backend/config/CaffeineConfig.java
+++ b/src/main/java/hello/backend/config/CaffeineConfig.java
@@ -1,4 +1,30 @@
 package hello.backend.config;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import hello.backend.video.dto.ImageToVideoRequest;
+import hello.backend.video.dto.TextToVideoRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
 public class CaffeineConfig {
+
+    @Bean
+    public Cache<String, TextToVideoRequest> requestTextCache() {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .maximumSize(1000)
+                .build();
+    }
+
+    @Bean
+    public Cache<String, ImageToVideoRequest> requestImageCache() {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .maximumSize(1000)
+                .build();
+    }
 }

--- a/src/main/java/hello/backend/video/contoller/VideoController.java
+++ b/src/main/java/hello/backend/video/contoller/VideoController.java
@@ -1,5 +1,6 @@
 package hello.backend.video.contoller;
 
+import ai.fal.client.queue.QueueStatus;
 import hello.backend.ai.deepseek.service.DeepSeekService;
 import hello.backend.video.dto.*;
 import hello.backend.video.service.VideoService;
@@ -28,10 +29,14 @@ public class VideoController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
     })
     @PostMapping("/texts/Kling-pro")
-    public ResponseEntity<TextToVideoResponse> createTextToVideoKling(@RequestBody TextToVideoRequest request) {
-        TextToVideoResponse createTextToVideo = videoService.createTextToVideo(request);
+    public ResponseEntity<SubmitQueueResponse> createTextToVideo(@RequestBody TextToVideoRequest request) {
+        QueueStatus.InQueue inQueue = videoService.createTextToVideo(request);
+        SubmitQueueResponse response = new SubmitQueueResponse(
+                inQueue.getRequestId(),
+                "요청이 큐에 등록되었습니다."
+        );
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(createTextToVideo);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @Operation(summary = "image to video 생성(Kling-pro-v1.6 모델)", description = "이미지를 기반으로 영상을 생성합니다.")
@@ -43,12 +48,44 @@ public class VideoController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
     })
     @PostMapping("/images/Kling-pro")
-    public ResponseEntity<ImageToVideoResponse> createImageToVideoKling(@RequestBody ImageToVideoRequest request) {
-        ImageToVideoResponse createImageToVideo = videoService.createImageToVideo(request);
+    public ResponseEntity<SubmitQueueResponse> createImageToVideo(@RequestBody ImageToVideoRequest request) {
+        QueueStatus.InQueue inQueue = videoService.createImageToVideo(request);
+        SubmitQueueResponse response = new SubmitQueueResponse(
+                inQueue.getRequestId(),
+                "요청이 큐에 등록되었습니다."
+        );
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(createImageToVideo);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+    //--------------------------------------------------------------------------------------------------
+    @Operation(summary = "생성중인 비디오 조회(polling)", description = "생성중인 비디오를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "비디오 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "잘못된 요청: 아직 생성중입니다.")
+    })
+    @GetMapping("/texts/{requestId}")
+    public ResponseEntity<TextToVideoResponse> getTextToVideo(
+            @Parameter(description = "조회할 비디오의 ID", required = true)
+            @PathVariable String requestId) {
+        TextToVideoResponse response = videoService.getTextToVideo(requestId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @Operation(summary = "생성중인 비디오 조회(polling)", description = "생성중인 비디오를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "비디오 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "잘못된 요청: 아직 생성중입니다.")
+    })
+    @GetMapping("/images/{requestId}")
+    public ResponseEntity<ImageToVideoResponse> getImageToVideo(
+            @Parameter(description = "조회할 비디오의 ID", required = true)
+            @PathVariable String requestId) {
+        ImageToVideoResponse response = videoService.getImeageToVideo(requestId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+    //--------------------------------------------------------------------------------------------------
     @Operation(summary = "비디오 저장", description = "생성된 비디오를 저장합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "비디오 저장 성공"),
@@ -59,12 +96,11 @@ public class VideoController {
             @Parameter(description = "저장할 회원의 ID", required = true)
             @PathVariable Long userId,
             @RequestBody SaveRequest request) {
-
         SaveResponse response = videoService.saveVideo(userId, request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
-
+    //--------------------------------------------------------------------------------------------------
     @Operation(summary = "DeepSeek prompt 테스트(text)", description = "prompt를 DeepSeek에 보내 변환된 결과를 확인합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "변환 성공")
@@ -72,6 +108,7 @@ public class VideoController {
     @PostMapping("/transforms/Text")
     public ResponseEntity<String> textTransFormScript(@RequestBody String prompt) {
         String result = deepSeekService.textTransFormScript(prompt);
+
         return ResponseEntity.ok(result);
     }
 
@@ -82,6 +119,7 @@ public class VideoController {
     @PostMapping("/transforms/Image")
     public ResponseEntity<String> imagetransformPrompt(@RequestBody String prompt) {
         String result = deepSeekService.imageTransFormScript(prompt);
+
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/hello/backend/video/dto/ImageToVideoResponse.java
+++ b/src/main/java/hello/backend/video/dto/ImageToVideoResponse.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 public class ImageToVideoResponse {
+    private String status;
     private String videoUrl;
     private String duration;
     private String aspect_ratio;

--- a/src/main/java/hello/backend/video/dto/SubmitQueueResponse.java
+++ b/src/main/java/hello/backend/video/dto/SubmitQueueResponse.java
@@ -1,0 +1,4 @@
+package hello.backend.video.dto;
+
+public class SubmitQueueResponse {
+}

--- a/src/main/java/hello/backend/video/dto/SubmitQueueResponse.java
+++ b/src/main/java/hello/backend/video/dto/SubmitQueueResponse.java
@@ -1,4 +1,13 @@
 package hello.backend.video.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
 public class SubmitQueueResponse {
+    String requestId;
+    String message;
 }

--- a/src/main/java/hello/backend/video/dto/TextToVideoResponse.java
+++ b/src/main/java/hello/backend/video/dto/TextToVideoResponse.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 public class TextToVideoResponse {
+    private String status;
     private String videoUrl;
     private String duration;
     private String aspect_ratio;

--- a/src/main/java/hello/backend/video/service/VideoService.java
+++ b/src/main/java/hello/backend/video/service/VideoService.java
@@ -2,8 +2,11 @@ package hello.backend.video.service;
 
 import ai.fal.client.FalClient;
 import ai.fal.client.Output;
-import ai.fal.client.SubscribeOptions;
+import ai.fal.client.queue.QueueResultOptions;
 import ai.fal.client.queue.QueueStatus;
+import ai.fal.client.queue.QueueStatusOptions;
+import ai.fal.client.queue.QueueSubmitOptions;
+import com.github.benmanes.caffeine.cache.Cache;
 import com.google.gson.JsonObject;
 import hello.backend.ai.deepseek.service.DeepSeekService;
 import hello.backend.error.ErrorCode;
@@ -20,6 +23,7 @@ import org.springframework.stereotype.Service;
 import ai.fal.client.exception.FalException;
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -30,43 +34,29 @@ public class VideoService {
     private final UserRepository userRepository;
     private final FalClient falClient;
     private final DeepSeekService deepSeekService;
+    private final Cache<String, TextToVideoRequest> requestTextCache;
+    private final Cache<String, ImageToVideoRequest> requestImageCache;
 
-    //image-to-video(kling 모델) 생성
+    //image-to-video(kling 모델) 생성 - 비동기 큐
     @Transactional
-    public TextToVideoResponse createTextToVideo(TextToVideoRequest request) {
-        String finalprompt = deepSeekService.textTransFormScript(request.getPrompt());
+    public QueueStatus.InQueue createTextToVideo(TextToVideoRequest request) {
+        String finalprompt = deepSeekService.imageTransFormScript(request.getPrompt());
 
         Map<String, Object> input = Map.of(
                 "prompt", finalprompt,
                 "duration", request.getDuration(),
-                "aspect_ratio", request.getAspect_ratio(),
-                "negative_prompt", "blur, distort, and low quality",
-                "cfg_scale", 0.5
+                "aspect_ratio", request.getAspect_ratio()
         );
 
-        SubscribeOptions<JsonObject> options = SubscribeOptions.<JsonObject>builder()
+        QueueSubmitOptions options = QueueSubmitOptions.builder()
                 .input(input)
-                .logs(true)
-                .resultType(JsonObject.class)
-                .onQueueUpdate(update -> {
-                    if (update instanceof QueueStatus.InProgress progress) {
-                        System.out.println(progress.getLogs());
-                    }
-                })
                 .build();
-
         try {
-            Output<JsonObject> output = falClient.subscribe("fal-ai/kling-video/v1.6/pro/text-to-video", options);
+            QueueStatus.InQueue inQueue = falClient.queue().submit("fal-ai/kling-video/v1.6/pro/text-to-video", options);
+            String requestId = inQueue.getRequestId();
+            requestTextCache.put(requestId, request);
 
-            JsonObject result = output.getData();
-            String videoUrl = extractVideoUrl(result);
-
-            return TextToVideoResponse.builder()
-                    .videoUrl(videoUrl)
-                    .duration(request.getDuration())
-                    .aspect_ratio(request.getAspect_ratio())
-                    .createdAt(LocalDateTime.now())
-                    .build();
+            return inQueue;
         } catch (FalException e) {
             log.error("🔥 Fal 예외 발생: {}", e.getMessage(), e);
             String msg = e.getMessage();
@@ -86,47 +76,32 @@ public class VideoService {
                     throw new BusinessException(ErrorCode.FAL_INTERNAL_ERROR, "AI 서버 내부 오류입니다.");
                 }
             }
+
             throw new BusinessException(ErrorCode.FAL_INTERNAL_ERROR, "Fal 예외 발생: " + msg);
         }
     }
 
-    //image-to-video(kling 모델) 생성
+    //image-to-video(kling 모델) 생성 - 비동기 큐
     @Transactional
-    public ImageToVideoResponse createImageToVideo(ImageToVideoRequest request) {
-        String finalprompt = deepSeekService.textTransFormScript(request.getPrompt());
+    public QueueStatus.InQueue createImageToVideo(ImageToVideoRequest request) {
+        String finalprompt = deepSeekService.imageTransFormScript(request.getPrompt());
 
         Map<String, Object> input = Map.of(
                 "prompt", finalprompt,
                 "image_url", request.getImageUrl(),
                 "duration", request.getDuration(),
-                "aspect_ratio", request.getAspect_ratio(),
-                "negative_prompt", "blur, distort, and low quality",
-                "cfg_scale", 0.5
+                "aspect_ratio", request.getAspect_ratio()
         );
 
-        SubscribeOptions<JsonObject> options = SubscribeOptions.<JsonObject>builder()
+        QueueSubmitOptions options = QueueSubmitOptions.builder()
                 .input(input)
-                .logs(true)
-                .resultType(JsonObject.class)
-                .onQueueUpdate(update -> {
-                    if (update instanceof QueueStatus.InProgress progress) {
-                        System.out.println(progress.getLogs());
-                    }
-                })
                 .build();
-
         try {
-            Output<JsonObject> output = falClient.subscribe("fal-ai/kling-video/v1.6/pro/image-to-video", options);
+            QueueStatus.InQueue inQueue = falClient.queue().submit("fal-ai/kling-video/v1.6/pro/image-to-video", options);
+            String requestId = inQueue.getRequestId();
+            requestImageCache.put(requestId, request);
 
-            JsonObject result = output.getData();
-            String videoUrl = extractVideoUrl(result);
-
-            return ImageToVideoResponse.builder()
-                    .videoUrl(videoUrl)
-                    .duration(request.getDuration())
-                    .aspect_ratio(request.getAspect_ratio())
-                    .createdAt(LocalDateTime.now())
-                    .build();
+            return inQueue;
         } catch (FalException e) {
             log.error("🔥 Fal 예외 발생: {}", e.getMessage(), e);
             String msg = e.getMessage();
@@ -146,10 +121,87 @@ public class VideoService {
                     throw new BusinessException(ErrorCode.FAL_INTERNAL_ERROR, "AI 서버 내부 오류입니다.");
                 }
             }
+
             throw new BusinessException(ErrorCode.FAL_INTERNAL_ERROR, "Fal 예외 발생: " + msg);
         }
     }
+    //--------------------------------------------------------------------------------------------------
+    //text-to-video(kling 모델) 조회 - polling
+    public TextToVideoResponse getTextToVideo(String requestId) {
+        QueueStatusOptions statusOptions = QueueStatusOptions.builder()
+                .requestId(requestId)
+                .logs(true)
+                .build();
 
+        QueueStatus.StatusUpdate status = falClient.queue().status("fal-ai/kling-video/v1.6/pro/text-to-video", statusOptions);
+        String resultStatus = statusCheck(status);
+
+        if (!"completed".equals(resultStatus)) {
+            return TextToVideoResponse.builder()
+                    .status(resultStatus)
+                    .build();
+        }
+
+        QueueResultOptions<JsonObject> options = QueueResultOptions.<JsonObject>builder()
+                .requestId(requestId)
+                .resultType(JsonObject.class)
+                .build();
+
+        Output<JsonObject> output = falClient.queue().result("fal-ai/kling-video/v1.6/pro/text-to-video", options);
+        JsonObject result = output.getData();
+
+        log.info("result 로그: {}",result);
+
+        TextToVideoRequest cacheRequest = Optional.ofNullable(requestTextCache.getIfPresent(requestId))
+                .orElseThrow(() -> new BusinessException(ErrorCode.FAL_NOT_FOUND, "요청 정보를 찾을 수 없습니다."));
+
+        return TextToVideoResponse.builder()
+                .status(resultStatus)
+                .videoUrl(result.getAsJsonObject("video").get("url").getAsString())
+                .aspect_ratio(cacheRequest.getAspect_ratio())
+                .duration(cacheRequest.getDuration())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    //image-to-video(kling 모델) 조회 - polling
+    public ImageToVideoResponse getImeageToVideo(String requestId) {
+        QueueStatusOptions statusOptions = QueueStatusOptions.builder()
+                .requestId(requestId)
+                .logs(true)
+                .build();
+
+        QueueStatus.StatusUpdate status = falClient.queue().status("fal-ai/kling-video/v1.6/pro/image-to-video", statusOptions);
+        String resultStatus = statusCheck(status);
+
+        if (!"completed".equals(resultStatus)) {
+            return ImageToVideoResponse.builder()
+                    .status(resultStatus)
+                    .build();
+        }
+
+        QueueResultOptions<JsonObject> options = QueueResultOptions.<JsonObject>builder()
+                .requestId(requestId)
+                .resultType(JsonObject.class)
+                .build();
+
+        Output<JsonObject> output = falClient.queue().result("fal-ai/kling-video/v1.6/pro/image-to-video", options);
+        JsonObject result = output.getData();
+
+        log.info("result 로그: {}",result);
+
+        ImageToVideoRequest cacheRequest = Optional.ofNullable(requestImageCache.getIfPresent(requestId))
+                .orElseThrow(() -> new BusinessException(ErrorCode.FAL_NOT_FOUND, "요청 정보를 찾을 수 없습니다."));
+
+        return ImageToVideoResponse.builder()
+                .status(resultStatus)
+                .videoUrl(result.getAsJsonObject("video").get("url").getAsString())
+                .aspect_ratio(cacheRequest.getAspect_ratio())
+                .duration(cacheRequest.getDuration())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+    //--------------------------------------------------------------------------------------------------
     //video 저장
     @Transactional
     public SaveResponse saveVideo(Long userId, SaveRequest request) {
@@ -176,9 +228,7 @@ public class VideoService {
                 .createdAt(request.getCreatedAt())
                 .build();
     }
-
-    //----------------------------------------------
-    //예외처리
+    //--------------------------------------------------------------------------------------------------
     @Transactional
     public String extractVideoUrl(JsonObject result) {
         if (result == null || !result.has("video")) {
@@ -192,5 +242,18 @@ public class VideoService {
         }
 
         return videoObj.get("url").getAsString();
+    }
+
+    @Transactional
+    public String statusCheck(QueueStatus.StatusUpdate status) {
+        if (status instanceof QueueStatus.InQueue) {
+            return "queued";
+        } else if (status instanceof QueueStatus.InProgress) {
+            return "processing";
+        } else if (status instanceof QueueStatus.Completed) {
+            return "completed";
+        } else {
+            throw new BusinessException(ErrorCode.FAL_NOT_FOUND, "알 수 없는 상태입니다.");
+        }
     }
 }


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

Video 비동기 큐 적용 리팩토링 완료

---

### ✨ Description

<!-- write down the work details and show the execution results. -->

Video 비동기 큐 적용 리팩토링 완료했습니다.
기존 SSE -> fal.ai 측 Timeout Error를 발생하여 비동기 큐 방식으로 리팩토링했습니다.

![image](https://github.com/user-attachments/assets/2d1959bd-80c7-4471-8173-1cef6b5b9530)
- 사진과 같이 입력하면, requestId를 반환하고 서버측으로 요청을 보냅니다.

![image](https://github.com/user-attachments/assets/96f15e5a-625f-4595-b1a6-258f085865f1)
- Parameters에 requestId를 사용하여 영상의 생성 상태를 확인할 수 있습니다. (polling 방식)
1. queued -> 큐에 적재 전
2. processing -> 영상 생성중
3. completed -> 영상 생성 완료

<img width="725" alt="image" src="https://github.com/user-attachments/assets/7c5b5d0c-bd69-4aa7-b38e-852ac299b4b2" />
- 위처럼 영상 생성이 완료되면, url과 함께 영상 정보를 반환합니다.

임시캐시는 Caffeine 캐시를 사용했습니다. 그 이유는, 자바 라이브러리로 사용할 수 있습니다.
또한, ConcurrentHashMap구조 + TTL 지원해주기 때문에, 해당 소규모 프로젝트에서는 Redis 사용보다, Caffeine을 사용하는게 MVP구조상 더 적합하다고 판단했습니다.

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{51}
